### PR TITLE
Refactor/#25 로그인한 사용자 정보 받아오기

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
         "dotenv": "^16.4.7",
         "firebase": "^11.1.0",
         "http-proxy-middleware": "^3.0.3",
+        "jwt-decode": "^4.0.0",
         "react": "^18.2.0",
         "react-dom": "^18.2.0",
         "react-router-dom": "^6.17.0",
@@ -13562,6 +13563,14 @@
       },
       "engines": {
         "node": ">=4.0"
+      }
+    },
+    "node_modules/jwt-decode": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/jwt-decode/-/jwt-decode-4.0.0.tgz",
+      "integrity": "sha512-+KJGIyHgkGuIq3IEBNftfhW/LfWhXUIY6OmyVWjliu5KH1y0fw7VQ8YndE2O4qZdMSd9SqbnC8GOcZEy0Om7sA==",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/keyv": {

--- a/package.json
+++ b/package.json
@@ -11,6 +11,7 @@
     "dotenv": "^16.4.7",
     "firebase": "^11.1.0",
     "http-proxy-middleware": "^3.0.3",
+    "jwt-decode": "^4.0.0",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "react-router-dom": "^6.17.0",

--- a/src/components/CardList.jsx
+++ b/src/components/CardList.jsx
@@ -1,55 +1,62 @@
-import React from 'react';
-import '../styles/CardList.css';
+import React from "react";
+import "../styles/CardList.css";
 
-const Card = ({ id, name, startDate, endDate, reservationDate, festivalDate, onEventClick }) => {
-    return (
-        <div className="card" onClick={() => onEventClick(id)}>
-            <div className = "card-image">
-                {/*<img src = "image_url" alt = "image description" />*/}
-                {/*<span>사진</span>*/}
-            </div>
-            <div className = "card-content">
-                {startDate && endDate ? (
-                    <>
-                        <span className="event-date">{startDate} ~ </span>
-                        <span className="event-date">{endDate}</span>
-                    </>
-                ) : (
-                    <>
-                        <span className="event-date">축제일: {festivalDate}</span><br/>
-                        <span className="event-date">예매일: {reservationDate}</span>
-                    </>
-                )}
-                <p className = "event-name">{name}</p>
-            </div>
-        </div>
-    );
+const Card = ({
+  id,
+  name,
+  startDate,
+  endDate,
+  reservationDate,
+  festivalDate,
+  onEventClick,
+}) => {
+  return (
+    <div className="card" onClick={() => onEventClick(id)}>
+      <div className="card-image">
+        {/*<img src = "image_url" alt = "image description" />*/}
+        {/*<span>사진</span>*/}
+      </div>
+      <div className="card-content">
+        {startDate && endDate ? (
+          <>
+            <span className="event-date">{startDate} ~ </span>
+            <span className="event-date">{endDate}</span>
+          </>
+        ) : (
+          <>
+            <span className="event-date">축제일: {festivalDate}</span>
+            <br />
+            <span className="event-date">예매일: {reservationDate}</span>
+          </>
+        )}
+        <p className="event-name">{name}</p>
+      </div>
+    </div>
+  );
 };
 
 const CardList = ({ events, onEventClick }) => {
-    console.log('CardList received onEventClick:', onEventClick);
-    return (
-        <div className="card-list">
-            {events && events.length > 0 ? (
-                events.map((event) => (
-                    <div key={event.id}>
-                        <Card
-                            id={event.id}
-                            name={event.name}
-                            startDate={event.startDate}
-                            endDate={event.endDate}
-                            reservationDate={event.reservationDate}
-                            festivalDate={event.festivalDate}
-                            onEventClick={onEventClick} // onEventClick 전달
-                        />
-                    </div>
-                ))
-            ) : (
-                <p>결과가 없습니다.</p>
-            )}
-        </div>
-    );
+  return (
+    <div className="card-list">
+      {events && events.length > 0 ? (
+        events.map((event) => (
+          <div key={event.id}>
+            <Card
+              id={event.festivalId}
+              name={event.name}
+              startDate={event.startDate}
+              endDate={event.endDate}
+              reservationDate={event.reservationDate}
+              festivalDate={event.festivalDate}
+              onEventClick={onEventClick} // onEventClick 전달
+            />
+          </div>
+        ))
+      ) : (
+        <p>결과가 없습니다.</p>
+      )}
+    </div>
+  );
 };
-
 
 export default CardList;

--- a/src/components/reservation/ReservationInfo.jsx
+++ b/src/components/reservation/ReservationInfo.jsx
@@ -1,26 +1,74 @@
 import axios from "axios";
-import React, { useState } from "react";
+import React, { useContext, useRef } from "react";
 import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
+import { AuthContext } from "../../context/AuthContext";
 
 const ReservationInfo = ({ festivalId, selectedDate }) => {
   const navigate = useNavigate();
-  console.log(festivalId);
+  const {
+    accessToken,
+    setAccessToken,
+    refreshToken,
+    setRefreshToken,
+    userName,
+    setUserName,
+  } = useContext(AuthContext);
+  const accessTokenRef = useRef(accessToken);
 
   const handleNext = async () => {
-    // 로그인 시 이메일 하드 코딩 변경 예정
     try {
-      const apiResponse = await axios.post("/api/reservations", {
-        userId: 1,
-        festivalId: festivalId,
-        festivalDate: selectedDate
-      });
+      await axios.post(
+        "/api/reservations",
+        {
+          festivalId: festivalId,
+          festivalDate: selectedDate,
+        },
+        {
+          headers: {
+            Authorization: `Bearer ${accessTokenRef.current}`,
+          },
+        }
+      );
       navigate("/reservation/completed");
     } catch (error) {
-      alert(error.response.data.message);
+      if (error.response.data == "토큰 검증에 실패했습니다.") {
+        const status = await reissueAccessToken();
+        if (status === true) {
+          console.log(status);
+          await handleNext();
+        }
+      } else {
+        alert(error.response.data.message);
+      }
     }
   };
 
+  const reissueAccessToken = async () => {
+    try {
+      const apiResponse = await axios.post(`/api/refresh-token`, null, {
+        headers: {
+          Refreshtoken: refreshToken, // 리프레시 토큰을 인증 헤더로 추가
+        },
+        params: {
+          username: userName, // URL 파라미터로 사용자 이름 전달
+        },
+      });
+      const newAccessToken = apiResponse.data.accessToken;
+      console.log("accesstoken 재발급");
+      setAccessToken(newAccessToken);
+      accessTokenRef.current = newAccessToken;
+      return true;
+    } catch (error) {
+      if (error.response.data.message == "Refresh Token이 만료되었습니다.") {
+        setAccessToken("");
+        setRefreshToken("");
+        setUserName("");
+        alert("세션이 만료되었습니다. 다시 로그인 하세요.");
+        window.location.href = "/signin";
+      }
+    }
+  };
   return (
     <Container>
       <ReservationContainer>

--- a/src/context/AuthContext.js
+++ b/src/context/AuthContext.js
@@ -7,6 +7,7 @@ export const AuthProvider = ({ children }) => {
   const [refreshToken, setRefreshToken] = useState(() => localStorage.getItem('refreshToken') || "");
   const [userName, setUserName] = useState(() => localStorage.getItem('userName') || "");
   const [fcmToken, setFcmToken] = useState(() => localStorage.getItem('fcmToken') || "");
+  const [idToken, setIdToken] = useState(() => localStorage.getItem('idToken') || "");
 
   useEffect(() => {
     if (accessToken) {
@@ -32,7 +33,13 @@ export const AuthProvider = ({ children }) => {
     } else {
       localStorage.removeItem('fcmToken');
     }
-  }, [accessToken, refreshToken, userName, fcmToken]);
+
+    if (idToken) {
+      localStorage.setItem('idToken', idToken);
+    } else {
+      localStorage.removeItem('idToken');
+    }
+  }, [accessToken, refreshToken, userName, fcmToken, idToken]);
 
   return (
     <AuthContext.Provider
@@ -45,6 +52,8 @@ export const AuthProvider = ({ children }) => {
         setUserName,
         fcmToken,
         setFcmToken,
+        idToken,
+        setIdToken,
       }}
     >
       {children}

--- a/src/pages/Festival/FestivalDetail/FestivalPage.jsx
+++ b/src/pages/Festival/FestivalDetail/FestivalPage.jsx
@@ -73,7 +73,7 @@ const FestivalPage = () => {
       </div>
       <div className="festival-page-buttons">
         <FestivalButton label="채팅방 입장하기" onClick={handleEnterChatRoom} />
-        <FestivalButton label="예약하기" />
+        <FestivalButton label="예약하기" onClick={() => navigate(`/waiting-room/${eventId}`)}/>
       </div>
     </div>
   );

--- a/src/pages/auth/SignInPage.jsx
+++ b/src/pages/auth/SignInPage.jsx
@@ -11,7 +11,7 @@ function SignInPage() {
   const [error, setError] = useState(""); // 로그인 실패 시 에러 메시지
   const [success, setSuccess] = useState(""); // 성공 메시지 관리
 
-  const { setAccessToken, setRefreshToken, setUserName, setFcmToken } = useContext(AuthContext);
+  const { setAccessToken, setRefreshToken, setUserName, setFcmToken, setIdToken } = useContext(AuthContext);
 
   const navigate = useNavigate(); 
 
@@ -37,12 +37,15 @@ function SignInPage() {
       setError("");
 
       // 응답 데이터에서 토큰과 사용자 이름 추출
-      const { accessToken, refreshToken, userName } = response.data;
+      const { accessToken, refreshToken, userName, idToken } = response.data;
 
       // AuthContext에 저장
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUserName(userName);
+      setIdToken(idToken);
+
+      console.log(idToken);
 
       alert('로그인되었습니다!'); 
 

--- a/src/pages/main/MainPage.jsx
+++ b/src/pages/main/MainPage.jsx
@@ -30,7 +30,7 @@ const MainPage = () => {
             setEvents((prevEvents) => [
                 ...prevEvents,
                 ...festivals.map((festival) => ({
-                    id: festival.id,
+                    festivalId: festival.id,
                     name: festival.name,
                     startDate: festival.startDate.replace(/-/g, '.'),
                     endDate: festival.endDate.replace(/-/g, '.'),
@@ -49,9 +49,9 @@ const MainPage = () => {
     }, []);
 
     // 축제 카드 클릭 시 상세 페이지로 이동
-    const handleCardClick = (id) => {
-        console.log("Card clicked, event ID:", id);
-        navigate(`/festival-detail/${id}`); // 상세 페이지로 이동
+    const handleEventClick = (eventId) => {
+        console.log(eventId);
+        navigate(`/festival-detail/${eventId}`); // `/festival` 경로로 이동
     };
 
     // 검색어 입력 시 상태 업데이트
@@ -89,7 +89,7 @@ const MainPage = () => {
             const { festivals, hasNext } = response.data;
             setEvents(
                 festivals.map((festival) => ({
-                    id: festival.id,
+                    festivalId: festival.id,
                     name: festival.name,
                     startDate: festival.startDate.replace(/-/g, '.'),
                     endDate: festival.endDate.replace(/-/g, '.'),
@@ -117,7 +117,7 @@ const MainPage = () => {
                     <img src="/searchIcon.png" alt="Search" className="search-icon" />
                 </button>
             </div>
-            <CardList events={events} onEventClick={handleCardClick} />
+            <CardList events={events} onEventClick={handleEventClick} />
             {hasMore && (
                 <button className="more-button" onClick={fetchFestivalList}>
                     더 보기

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -1,89 +1,105 @@
-import { useNavigate } from 'react-router-dom';
-import React, {useContext, useEffect, useState} from 'react';
-import CardList from '../../components/CardList';
-import axios from 'axios';
-import '../../styles/CardList.css';
-import '../../styles/my/MyPage.css';
-import {AuthContext} from "../../context/AuthContext";
+import { useNavigate } from "react-router-dom";
+import React, { useContext, useEffect, useState } from "react";
+import CardList from "../../components/CardList";
+import axios from "axios";
+import "../../styles/CardList.css";
+import "../../styles/my/MyPage.css";
+import { AuthContext } from "../../context/AuthContext";
 
 const MyPage = () => {
-    const [events, setEvents] = useState([]);
-    const [error, setError] = useState(null);
-    const [lastId, setLastId] = useState(0);
-    const [limit] = useState(8);
-    const [hasMore, setHasMore] = useState(true);
-    const navigate = useNavigate();
-    const {accessToken} = useContext(AuthContext);
+  const [events, setEvents] = useState([]);
+  const [error, setError] = useState(null);
+  const [lastId, setLastId] = useState(0);
+  const [limit] = useState(8);
+  const [hasMore, setHasMore] = useState(true);
+  const navigate = useNavigate();
+  const { accessToken } = useContext(AuthContext);
 
-    // 예약 목록 가져오기
-    const fetchReservationList = async () => {
-        setError(null);
-        if (!hasMore) return;
+  // 예약 목록 가져오기
+  const fetchReservationList = async () => {
+    setError(null);
+    if (!hasMore) return;
 
-        try {
-            const response = await axios.get('/api/reservations', {
-                params: {
-                    lastId: lastId,
-                    limit: limit,
-                },
-                headers: {
-                    Authorization: `Bearer ${accessToken}`,
-                },
-            });
+    try {
+      const response = await axios.get("/api/reservations", {
+        params: {
+          lastId: lastId,
+          limit: limit,
+        },
+        headers: {
+          Authorization: `Bearer ${accessToken}`,
+        },
+      });
 
-            const { reservations, hasNext } = response.data;
+      const { reservations, hasNext } = response.data;
 
-            setEvents((prevEvents) => [
-                ...prevEvents,
-                ...reservations.map((reservation) => ({
-                    id: reservation.id,
-                    name: reservation.festivalInfo.name,
-                    reservationDate: `${reservation.reservationDate[0]}.${String(reservation.reservationDate[1]).padStart(2, '0')}.${String(reservation.reservationDate[2]).padStart(2, '0')}`,
-                    festivalDate: `${reservation.festivalDate[0]}.${String(reservation.festivalDate[1]).padStart(2, '0')}.${String(reservation.festivalDate[2]).padStart(2, '0')}`
-                })),
-            ]);
+      setEvents((prevEvents) => [
+        ...prevEvents,
+        ...reservations.map((reservation) => ({
+          id: reservation.id,
+          name: reservation.festivalInfo.name,
+          festivalId: reservation.festivalInfo.id,
+          reservationDate: `${reservation.reservationDate[0]}.${String(
+            reservation.reservationDate[1]
+          ).padStart(2, "0")}.${String(reservation.reservationDate[2]).padStart(
+            2,
+            "0"
+          )}`,
+          festivalDate: `${reservation.festivalDate[0]}.${String(
+            reservation.festivalDate[1]
+          ).padStart(2, "0")}.${String(reservation.festivalDate[2]).padStart(
+            2,
+            "0"
+          )}`,
+        })),
+      ]);
 
-            setLastId(response.data.lastId != null ? response.data.lastId : reservations[reservations.length - 1].id);
-            setHasMore(hasNext);
-        } catch (err) {
-            setError('예약 목록을 불러오는 중 문제가 발생했습니다.');
-        }
-    };
-
-    useEffect(() => {
+      setLastId(
+        response.data.lastId != null
+          ? response.data.lastId
+          : reservations[reservations.length - 1].id
+      );
+      setHasMore(hasNext);
+    } catch (error) {
+      if (error.response.data == "토큰 검증에 실패했습니다.") {
+        reissueAccessToken();
         fetchReservationList();
-    }, []);
+      }
+      setError("예약 목록을 불러오는 중 문제가 발생했습니다.");
+    }
+  };
 
-    // 카드 클릭 시 이벤트 처리
-    const handleEventClick = (eventId) => {
-        navigate(`/festival?id=${eventId}`); // `/festival` 경로로 이동
-    };
+  useEffect(() => {
+    fetchReservationList();
+  }, []);
 
-    return (
-        <div className="my-page-container">
-            <div className="my-page-header">
-                <p
-                    className="my-page-link"
-                    onClick={() => navigate('/chat')}
-                >
-                    내 채팅방
-                </p>
-                <p className="my-page-title">내 예약 조회</p>
-            </div>
-            {events.length > 0 ? (
-                <>
-                    <CardList events={events} />
-                    {hasMore && (
-                        <button className="more-button" onClick={fetchReservationList}>
-                            더 보기
-                        </button>
-                    )}
-                </>
-            ) : (
-                <p>예약 내역이 없습니다.</p>
-            )}
-        </div>
-    );
+  // 카드 클릭 시 이벤트 처리
+  const handleEventClick = (eventId) => {
+    navigate(`/festival-detail/${eventId}`); // `/festival` 경로로 이동
+  };
+
+  return (
+    <div className="my-page-container">
+      <div className="my-page-header">
+        <p className="my-page-link" onClick={() => navigate("/chat")}>
+          내 채팅방
+        </p>
+        <p className="my-page-title">내 예약 조회</p>
+      </div>
+      {events.length > 0 ? (
+        <>
+          <CardList events={events} onEventClick={handleEventClick} />
+          {hasMore && (
+            <button className="more-button" onClick={fetchReservationList}>
+              더 보기
+            </button>
+          )}
+        </>
+      ) : (
+        <p>예약 내역이 없습니다.</p>
+      )}
+    </div>
+  );
 };
 
 export default MyPage;

--- a/src/pages/my/MyPage.jsx
+++ b/src/pages/my/MyPage.jsx
@@ -61,10 +61,6 @@ const MyPage = () => {
       );
       setHasMore(hasNext);
     } catch (error) {
-      if (error.response.data == "토큰 검증에 실패했습니다.") {
-        reissueAccessToken();
-        fetchReservationList();
-      }
       setError("예약 목록을 불러오는 중 문제가 발생했습니다.");
     }
   };

--- a/src/pages/reservation/Reservation.jsx
+++ b/src/pages/reservation/Reservation.jsx
@@ -5,6 +5,7 @@ import Calendar from "../../components/reservation/Calendar";
 import ReservationInfo from "../../components/reservation/ReservationInfo";
 import axios from "axios";
 import { AuthContext } from "../../context/AuthContext";
+import { jwtDecode } from "jwt-decode";
 
 const Reservation = () => {
   const { festivalId } = useParams();
@@ -19,16 +20,16 @@ const Reservation = () => {
     setRefreshToken,
     userName,
     setUserName,
+    idToken,
   } = useContext(AuthContext);
   const accessTokenRef = useRef(accessToken);
 
   const handleLeaveQueue = async () => {
     try {
-      await axios.delete(`/api/queues/festival${festivalId}/leave-proceed`, {
-        headers: {
-          Authorization: `Bearer ${accessTokenRef.current}`, // 토큰을 인증 헤더로 추가
-        },
-      });
+      const email = jwtDecode(idToken).email;
+      await axios.delete(
+        `/api/queues/festival${festivalId}/users/${email}/leave-proceed`
+      );
       console.log("Successfully left the wait queue");
       return true;
     } catch (error) {

--- a/src/pages/reservation/Reservation.jsx
+++ b/src/pages/reservation/Reservation.jsx
@@ -1,9 +1,10 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext, useRef } from "react";
 import { useParams } from "react-router-dom";
 import styled from "styled-components";
 import Calendar from "../../components/reservation/Calendar";
 import ReservationInfo from "../../components/reservation/ReservationInfo";
 import axios from "axios";
+import { AuthContext } from "../../context/AuthContext";
 
 const Reservation = () => {
   const { festivalId } = useParams();
@@ -11,32 +12,86 @@ const Reservation = () => {
   const [startDate, setStartDate] = useState(null);
   const [endDate, setEndDate] = useState(null);
   const [isLoading, setIsLoading] = useState(true);
+  const {
+    accessToken,
+    setAccessToken,
+    refreshToken,
+    setRefreshToken,
+    userName,
+    setUserName,
+  } = useContext(AuthContext);
+  const accessTokenRef = useRef(accessToken);
 
-  // 대기 완료 열에서 유저를 제거하는 함수(로그인 시 이메일 하드 코딩 변경 예정)
   const handleLeaveQueue = async () => {
     try {
-      const email = "user10@example.com";
-      await axios.delete(
-        `/api/queues/festival${festivalId}/users/${email}/leave-proceed`
-      );
+      await axios.delete(`/api/queues/festival${festivalId}/leave-proceed`, {
+        headers: {
+          Authorization: `Bearer ${accessTokenRef.current}`, // 토큰을 인증 헤더로 추가
+        },
+      });
       console.log("Successfully left the wait queue");
+      return true;
     } catch (error) {
-      console.error("Error leaving the wait queue:", error);
+      if (error.response.data == "토큰 검증에 실패했습니다.") {
+        await reissueAccessToken(); // refreshToken으로 accessToken을 재발급
+      }
+    }
+  };
+
+  const fetchDateRange = async () => {
+    try {
+      const apiResponse = await axios.get(`/api/festivals/${festivalId}`, {
+        headers: {
+          Authorization: `Bearer ${accessTokenRef.current}`, // 토큰을 인증 헤더로 추가
+        },
+      });
+      setStartDate(apiResponse.data.startDate);
+      setEndDate(apiResponse.data.endDate);
+      setIsLoading(false);
+    } catch (error) {
+      console.log(error);
     }
   };
 
   // API 요청으로 축제 정보
   useEffect(() => {
-    const fetchDateRange = async () => {
-      const apiResponse = await axios.get(`/api/festivals/${festivalId}`);
-      setStartDate(apiResponse.data.startDate);
-      setEndDate(apiResponse.data.endDate);
-      setIsLoading(false);
+    const initialize = async () => {
+      try {
+        // Access 토큰 갱신 및 초기화 작업
+        await handleLeaveQueue();
+        await fetchDateRange();
+      } catch (error) {
+        console.error("Initialization error:", error);
+      }
     };
-
-    handleLeaveQueue();
-    fetchDateRange();
+    // 토큰 재발급이 끝났고 accessToken이 있으면 렌더링
+    initialize();
   }, []);
+
+  const reissueAccessToken = async () => {
+    try {
+      const apiResponse = await axios.post(`/api/refresh-token`, null, {
+        headers: {
+          Refreshtoken: refreshToken, // 리프레시 토큰을 인증 헤더로 추가
+        },
+        params: {
+          username: userName, // URL 파라미터로 사용자 이름 전달
+        },
+      });
+      const newAccessToken = apiResponse.data.accessToken;
+      console.log("accesstoken 재발급");
+      setAccessToken(newAccessToken);
+      accessTokenRef.current = newAccessToken;
+    } catch (error) {
+      if (error.response.data.message == "Refresh Token이 만료되었습니다.") {
+        setAccessToken("");
+        setRefreshToken("");
+        setUserName("");
+        alert("세션이 만료되었습니다. 다시 로그인 하세요.");
+        window.location.href = "/signin";
+      }
+    }
+  };
 
   // 날짜 변경 핸들러
   const handleDateChange = (date) => {

--- a/src/pages/reservation/ReservationCompleted.jsx
+++ b/src/pages/reservation/ReservationCompleted.jsx
@@ -1,7 +1,10 @@
 import React from "react";
+import { useNavigate } from "react-router-dom";
 import styled from "styled-components";
 
 const ReservationCompleted = () => {
+  const navigate = useNavigate();
+
   return (
     <Container>
       <ReservationContent>
@@ -10,7 +13,7 @@ const ReservationCompleted = () => {
           alt="체크 이미지"
         />
         <TitleText>예약이 확정되었습니다.</TitleText>
-        <ConfirmText>확인</ConfirmText>
+        <ConfirmText onClick={() => navigate('/mypage')}>확인</ConfirmText>
       </ReservationContent>
     </Container>
   );

--- a/src/pages/reservation/WaitingRoom.jsx
+++ b/src/pages/reservation/WaitingRoom.jsx
@@ -3,37 +3,21 @@ import styled from "styled-components";
 import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
 import { AuthContext } from "../../context/AuthContext";
+import { jwtDecode } from "jwt-decode";
 
 const WaitingRoom = () => {
   const { festivalId } = useParams();
   const navigate = useNavigate();
   const [userRank, setUserRank] = useState(null);
-  const {
-    accessToken,
-    setAccessToken,
-    refreshToken,
-    setRefreshToken,
-    userName,
-    setUserName,
-  } = useContext(AuthContext);
-  let isRefreshing = false;
-
-  useEffect(() => { 
-    const fetchData = async () => {
-      const status = await reissueAccessToken();
-      console.log(status);
-      if (status === true) {
-        console.log(status);
-        registerWaitingRoom();
-      }
-    };
-  
-    fetchData();
-  }, []);
-  
+  const { idToken } = useContext(AuthContext);
+  const email = jwtDecode(idToken).email;
 
   useEffect(() => {
-    const interval = setInterval(fetchUserRank, 400);
+    registerWaitingRoom();
+  }, []);
+
+  useEffect(() => {
+    const interval = setInterval(fetchUserRank, 1000);
     return () => clearInterval(interval);
   }, [userRank]);
 
@@ -73,14 +57,12 @@ const WaitingRoom = () => {
   // 대기열에서 유저를 제거하는 함수
   const handleLeaveQueue = async () => {
     try {
-      await axios.delete(`/api/queues/festival${festivalId}/leave`, {
-        headers: {
-          Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
-        },
-      });
+      await axios.delete(
+        `/api/queues/festival${festivalId}/users/${email}/leave`
+      );
       console.log("Successfully left the wait queue");
     } catch (error) {
-      console.log(error);
+      console.error("Error leaving the wait queue:", error);
     }
   };
 
@@ -89,81 +71,35 @@ const WaitingRoom = () => {
     try {
       console.log("대기열에 유저를 등록");
       const response = await axios.get(
-        `/api/queues/festival${festivalId}/waiting-room`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
-          },
-        }
+        `/api/queues/festival${festivalId}/waiting-room/users/${email}`
       );
       console.log("Response:", response.data); // 응답 데이터 확인
       setUserRank(response.data.rank); // userRank 상태 업데이트
     } catch (error) {
-      console.log(error);
+      console.error("Error fetching waiting room data:", error);
     }
   };
 
   const fetchUserRank = async () => {
     try {
       const response = await axios.get(
-        `/api/queues/festival${festivalId}/rank`,
-        {
-          headers: {
-            Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
-          },
-        }
+        `/api/queues/festival${festivalId}/users/${email}/rank`
       );
       const { rank } = response.data;
       console.log(response.data);
       if (rank <= 0) {
         // 다시 한번 더 확인
         const response = await axios.get(
-          `/api/queues/festival${festivalId}/allowed`,
-          {
-            headers: {
-              Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
-            },
-          }
+          `/api/queues/festival${festivalId}/users/${email}/allowed`
         );
         if (response.data.allowed) {
           navigate(`/reservation/${festivalId}`);
         }
       } else {
-        console.log(rank);
         setUserRank(rank);
       }
     } catch (error) {
       console.log(error);
-    }
-  };
-
-  const reissueAccessToken = async () => {
-    try {
-      if (!isRefreshing) {
-        isRefreshing = true; // 토큰 재발급 시작
-        const apiResponse = await axios.post(`/api/refresh-token`, null, {
-          headers: {
-            Refreshtoken: refreshToken, // 리프레시 토큰을 인증 헤더로 추가
-          },
-          params: {
-            username: userName, // URL 파라미터로 사용자 이름 전달
-          },
-        });
-        const newAccessToken = apiResponse.data.accessToken;
-        console.log("accesstoken 재발급");
-        setAccessToken(newAccessToken);
-        return true;
-      }
-    } catch (error) {
-      if (error.response.data.message == "Refresh Token이 만료되었습니다.") {
-        setAccessToken("");
-        setRefreshToken("");
-        setUserName("");
-        alert("세션이 만료되었습니다. 다시 로그인 하세요.");
-        window.location.href = "/signin";
-      }
-    } finally {
-      isRefreshing = false;
     }
   };
 

--- a/src/pages/reservation/WaitingRoom.jsx
+++ b/src/pages/reservation/WaitingRoom.jsx
@@ -1,16 +1,36 @@
-import React, { useState, useEffect } from "react";
+import React, { useState, useEffect, useContext } from "react";
 import styled from "styled-components";
 import { useNavigate, useParams } from "react-router-dom";
 import axios from "axios";
+import { AuthContext } from "../../context/AuthContext";
 
 const WaitingRoom = () => {
   const { festivalId } = useParams();
   const navigate = useNavigate();
   const [userRank, setUserRank] = useState(null);
+  const {
+    accessToken,
+    setAccessToken,
+    refreshToken,
+    setRefreshToken,
+    userName,
+    setUserName,
+  } = useContext(AuthContext);
+  let isRefreshing = false;
 
-  useEffect(() => {
-    registerWaitingRoom();
+  useEffect(() => { 
+    const fetchData = async () => {
+      const status = await reissueAccessToken();
+      console.log(status);
+      if (status === true) {
+        console.log(status);
+        registerWaitingRoom();
+      }
+    };
+  
+    fetchData();
   }, []);
+  
 
   useEffect(() => {
     const interval = setInterval(fetchUserRank, 400);
@@ -53,44 +73,57 @@ const WaitingRoom = () => {
   // 대기열에서 유저를 제거하는 함수
   const handleLeaveQueue = async () => {
     try {
-      // 로그인 시 이메일 하드 코딩 변경 예정
-      const email = "user10@example.com";
-      await axios.delete(
-        `/api/queues/festival${festivalId}/users/${email}/leave`
-      );
+      await axios.delete(`/api/queues/festival${festivalId}/leave`, {
+        headers: {
+          Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
+        },
+      });
       console.log("Successfully left the wait queue");
     } catch (error) {
-      console.error("Error leaving the wait queue:", error);
+      console.log(error);
     }
   };
 
+  // 대기열에 유저를 등록
   const registerWaitingRoom = async () => {
     try {
-      // 로그인 시 이메일 하드 코딩 변경 예정
-      const email = "user10@example.com";
+      console.log("대기열에 유저를 등록");
       const response = await axios.get(
-        `/api/queues/festival${festivalId}/waiting-room/users/${email}`
+        `/api/queues/festival${festivalId}/waiting-room`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
+          },
+        }
       );
       console.log("Response:", response.data); // 응답 데이터 확인
       setUserRank(response.data.rank); // userRank 상태 업데이트
     } catch (error) {
-      console.error("Error fetching waiting room data:", error);
+      console.log(error);
     }
   };
 
   const fetchUserRank = async () => {
     try {
-      // 로그인 시 이메일 하드 코딩 변경 예정
-      const email = "user10@example.com";
       const response = await axios.get(
-        `/api/queues/festival${festivalId}/users/${email}/rank`
+        `/api/queues/festival${festivalId}/rank`,
+        {
+          headers: {
+            Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
+          },
+        }
       );
       const { rank } = response.data;
       console.log(response.data);
       if (rank <= 0) {
         // 다시 한번 더 확인
         const response = await axios.get(
-          `/api/queues/festival${festivalId}/users/${email}/allowed`
+          `/api/queues/festival${festivalId}/allowed`,
+          {
+            headers: {
+              Authorization: `Bearer ${accessToken}`, // 토큰을 인증 헤더로 추가
+            },
+          }
         );
         if (response.data.allowed) {
           navigate(`/reservation/${festivalId}`);
@@ -100,9 +133,40 @@ const WaitingRoom = () => {
         setUserRank(rank);
       }
     } catch (error) {
-      console.error("Error fetching user rank:", error);
+      console.log(error);
     }
   };
+
+  const reissueAccessToken = async () => {
+    try {
+      if (!isRefreshing) {
+        isRefreshing = true; // 토큰 재발급 시작
+        const apiResponse = await axios.post(`/api/refresh-token`, null, {
+          headers: {
+            Refreshtoken: refreshToken, // 리프레시 토큰을 인증 헤더로 추가
+          },
+          params: {
+            username: userName, // URL 파라미터로 사용자 이름 전달
+          },
+        });
+        const newAccessToken = apiResponse.data.accessToken;
+        console.log("accesstoken 재발급");
+        setAccessToken(newAccessToken);
+        return true;
+      }
+    } catch (error) {
+      if (error.response.data.message == "Refresh Token이 만료되었습니다.") {
+        setAccessToken("");
+        setRefreshToken("");
+        setUserName("");
+        alert("세션이 만료되었습니다. 다시 로그인 하세요.");
+        window.location.href = "/signin";
+      }
+    } finally {
+      isRefreshing = false;
+    }
+  };
+
   return (
     <Container>
       <Circle>


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #25 

## 📝 작업 내용
- 대기열, 예약 페이지 로그인한 사용자 정보 받아오도록 변경
- 페이지 연결 작업

리프레시 토큰 만료 시 화면
![image](https://github.com/user-attachments/assets/cfd1e72c-72e6-4b94-867f-b5ef61fecb88)
확인 버튼 누르면 로그인 페이지로 이동하도록 구현

## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
npm install 해주세요
