### PR TITLE
Refactor/ 채팅 로그인한 유저 정보로 변경

### DIFF
--- a/src/api/chatJoinApi.js
+++ b/src/api/chatJoinApi.js
@@ -1,10 +1,12 @@
 import axios from "axios";
 
 // 채팅방 참여 API
-export const joinChatRoom = async (chatRoomId, userId) => {
+export const joinChatRoom = async (chatRoomId, accessToken) => {
   try {
-    const response = await axios.post(`/api/festivals/chatting/${chatRoomId}/join`, {}, {
-      params: { userId },
+    const response = await axios.post(`/api/festivals/chatting/${chatRoomId}/join`, null, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
     });
     return response.data; // 반환된 chatRoomId
   } catch (error) {

--- a/src/api/myChatListApi.js
+++ b/src/api/myChatListApi.js
@@ -1,9 +1,13 @@
 import axios from "axios";
 
 // 채팅방 리스트 가져오기
-export const getChatRoomList = async (userId) => {
+export const getChatRoomList = async (accessToken) => {
   try {
-    const response = await axios.get(`/api/festivals/chatting/list/${userId}`);
+    const response = await axios.get(`/api/festivals/chatting/list`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`
+      }
+    });
     return response.data; // 데이터 반환
   } catch (error) {
     console.error("Error fetching chat room list:", error);
@@ -12,11 +16,11 @@ export const getChatRoomList = async (userId) => {
 };
 
 // 채팅방 나가기
-export const leaveChatRoom = async (userId, chatRoomId) => {
+export const leaveChatRoom = async (accessToken, chatRoomId) => {
   try {
     const response = await axios.delete(
-      `/api/festivals/chatting/delete/${userId}`,
-      { params: { chatRoomId } } // query parameter로 chatRoomId 전달
+      `/api/festivals/chatting/delete`,
+        { params: { chatRoomId }, headers: { Authorization: `Bearer ${accessToken}`} } // query parameter로 chatRoomId 전달
     );
     return response.data; // 데이터 반환
   } catch (error) {

--- a/src/pages/Chat/ChatList.jsx
+++ b/src/pages/Chat/ChatList.jsx
@@ -1,16 +1,17 @@
-import React, { useState, useEffect } from "react";
+import React, {useState, useEffect, useContext} from "react";
 import { getChatRoomList, leaveChatRoom } from "../../api/myChatListApi"; // API 호출 함수
 import "./ChatPage.css";
+import {AuthContext} from "../../context/AuthContext";
 
 const ChatList = ({ onChatSelect }) => {
   const [chats, setChats] = useState([]); // 채팅방 목록 상태
   const [loading, setLoading] = useState(true); // 로딩 상태
-  const userId = 1; // 하드코딩된 사용자 ID
+  const {accessToken} = useContext(AuthContext);
 
   useEffect(() => {
     const fetchChats = async () => {
       try {
-        const chatRooms = await getChatRoomList(userId); // API 호출
+        const chatRooms = await getChatRoomList(accessToken); // API 호출
         setChats(chatRooms); // 상태에 데이터 저장
       } catch (error) {
         console.error("채팅방 목록을 가져오는 중 오류:", error);
@@ -32,7 +33,7 @@ const ChatList = ({ onChatSelect }) => {
 
   const handleLeaveChat = async (chat) => {
     try {
-      await leaveChatRoom(userId, chat.id); // userId와 chatRoomId를 API로 전달
+      await leaveChatRoom(accessToken, chat.id); // userId와 chatRoomId를 API로 전달
       setChats((prevChats) => prevChats.filter((c) => c.id !== chat.id)); // 상태에서 채팅방 제거
     } catch (error) {
       console.error("채팅방 나가기 중 오류:", error);

--- a/src/pages/Chat/ChatPage.jsx
+++ b/src/pages/Chat/ChatPage.jsx
@@ -1,18 +1,20 @@
-import React, { useState, useEffect } from "react";
+import React, {useState, useEffect, useContext} from "react";
 import { useLocation } from "react-router-dom";
 import ChatList from "./ChatList";
 import ChatRoom from "./ChatRoom";
 import { enterChatRoom } from "../../api/chatJoinApi"; // API 호출 함수
 import "./ChatPage.css";
+import {AuthContext} from "../../context/AuthContext";
 
 const ChatPage = () => {
   const location = useLocation();
   const [selectedChat, setSelectedChat] = useState(location.state?.chat || null);
   const [messages, setMessages] = useState(location.state?.messages || []);
+  const {userId} = useContext(AuthContext);
 
   const handleChatSelect = async (chat) => {
     try {
-      const chatRoomData = await enterChatRoom(chat.id, 1); // userId는 하드코딩된 값
+      const chatRoomData = await enterChatRoom(chat.id, userId);
       setSelectedChat(chat);
       setMessages(chatRoomData.messages || []);
     } catch (error) {

--- a/src/pages/Chat/ChatRoom.jsx
+++ b/src/pages/Chat/ChatRoom.jsx
@@ -4,7 +4,7 @@ import { getChatMessages } from "../../api/chatApi"; // 메시지 가져오는 A
 import { Stomp } from "@stomp/stompjs";
 
 const ChatRoom = ({ chat, messages: initialMessages }) => {
-  const userId = localStorage.getItem("userId");
+  const userId = Number(localStorage.getItem("userId"));
   const userNickname = localStorage.getItem("userNickname");
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState("");

--- a/src/pages/Chat/ChatRoom.jsx
+++ b/src/pages/Chat/ChatRoom.jsx
@@ -1,10 +1,11 @@
-import React, { useState, useEffect, useRef } from "react";
+import React, {useState, useEffect, useRef, useContext} from "react";
 import "./ChatRoom.css";
 import { getChatMessages } from "../../api/chatApi"; // 메시지 가져오는 API 호출 함수
 import { Stomp } from "@stomp/stompjs";
 
 const ChatRoom = ({ chat, messages: initialMessages }) => {
-  const user = { userId: 1, senderName: "John Doe" };
+  const userId = localStorage.getItem("userId");
+  const userNickname = localStorage.getItem("userNickname");
   const [messages, setMessages] = useState([]);
   const [newMessage, setNewMessage] = useState("");
   const [lastEvaluatedSendTime, setLastEvaluatedSendTime] = useState(null);
@@ -33,7 +34,7 @@ const ChatRoom = ({ chat, messages: initialMessages }) => {
       const formattedMessages = initialMessages
         .map((message) => ({
           ...message,
-          isMyMessage: message.senderId === user.userId,
+          isMyMessage: message.senderId === userId,
         }))
         .sort((a, b) => a.sendTime - b.sendTime); // 시간순 정렬
       setMessages(formattedMessages);
@@ -51,7 +52,7 @@ const ChatRoom = ({ chat, messages: initialMessages }) => {
     const client = Stomp.over(() => new WebSocket(socketUrl));    
     client.reconnectDelay = 5000;
   
-    client.connect({ userId: user.userId, chatRoomId: chat.id }, () => {
+    client.connect({ userId: userId, chatRoomId: chat.id }, () => {
       console.log("웹소켓 연결 성공");
   
       client.subscribe(`/topic/chat/${chat.id}`, (message) => {
@@ -70,7 +71,7 @@ const ChatRoom = ({ chat, messages: initialMessages }) => {
           () => {
             console.log("웹소켓 연결 종료");
           },
-          { userId: user.userId, chatRoomId: chat.id } // 헤더 추가
+          { userId: userId, chatRoomId: chat.id } // 헤더 추가
         );
       }
     };
@@ -91,14 +92,14 @@ const ChatRoom = ({ chat, messages: initialMessages }) => {
 
     try {
       const previousMessages = await getChatMessages(
-        chat.id,
-        lastEvaluatedSendTime,
-        user.userId
+          chat.id,
+          lastEvaluatedSendTime,
+          userId
       );
       if (previousMessages.messages?.length > 0) {
         const formattedMessages = previousMessages.messages.map((message) => ({
           ...message,
-          isMyMessage: message.senderId === user.userId,
+          isMyMessage: message.senderId === userId,
         }));
         setMessages((prev) => [...formattedMessages, ...prev]);
         setLastEvaluatedSendTime(previousMessages.lastEvaluatedSendTime);
@@ -128,8 +129,8 @@ const ChatRoom = ({ chat, messages: initialMessages }) => {
     if (!newMessage.trim()) return;
 
     const messageData = {
-      senderId: user.userId,
-      senderName:user.senderName,
+      senderId: userId,
+      senderName: userNickname,
       content: newMessage,
       sendTime: Math.floor(Date.now() / 1000),
       chatRoomId: chat.id,

--- a/src/pages/Festival/FestivalDetail/FestivalPage.jsx
+++ b/src/pages/Festival/FestivalDetail/FestivalPage.jsx
@@ -1,17 +1,19 @@
-import React, { useEffect, useState } from "react";
+import React, {useContext, useEffect, useState} from "react";
 import { useLocation, useNavigate } from "react-router-dom";
 import { joinChatRoom, enterChatRoom } from "../../../api/chatJoinApi";
 import FestivalImage from "./FestivalImage";  // 이미지를 처리하는 컴포넌트
 import FestivalButton from "./FestivalButton";
 import "./FestivalDetail.css";
 import axios from "axios";
+import {AuthContext} from "../../../context/AuthContext";
 
 const FestivalPage = () => {
   const location = useLocation();
   const eventId = location.pathname.split('/')[2];
   console.log("Event ID from URL:", eventId);  
   const navigate = useNavigate();
-  const userId = 1; // 하드코딩된 사용자 ID
+  const {accessToken} = useContext(AuthContext);
+  const {userId} = useContext(AuthContext);
 
   const [event, setEvent] = useState(null);
   const [loading, setLoading] = useState(true);
@@ -50,7 +52,7 @@ const FestivalPage = () => {
 
   const handleEnterChatRoom = async () => {
     try {
-      const chatRoomId = await joinChatRoom(event.id, userId);
+      const chatRoomId = await joinChatRoom(event.id, accessToken);
       const chatRoomData = await enterChatRoom(chatRoomId, userId);
 
       navigate("/chat", {

--- a/src/pages/auth/SignInPage.jsx
+++ b/src/pages/auth/SignInPage.jsx
@@ -37,12 +37,15 @@ function SignInPage() {
       setError("");
 
       // 응답 데이터에서 토큰과 사용자 이름 추출
-      const { accessToken, refreshToken, userName } = response.data;
+      const { accessToken, refreshToken, userName, userId, userNickname } = response.data;
 
       // AuthContext에 저장
       setAccessToken(accessToken);
       setRefreshToken(refreshToken);
       setUserName(userName);
+
+      localStorage.setItem("userId", userId);
+      localStorage.setItem("userNickname", userNickname);
 
       alert('로그인되었습니다!'); 
 


### PR DESCRIPTION
## 🛰️ Issue Number
- resolve #

## 📝 작업 내용
- [refactor: 로그인 후 user id, name localStorage에 저장](https://github.com/SomSomParty/SomSomParty_FE/commit/963cf173dc9fc568ac1137bf050ab59b00cf9e66)
-   [refactor: 채팅 로그인한 유저 정보로 변경](https://github.com/SomSomParty/SomSomParty_FE/commit/90d33e2e5cae0486a1611e8e0ceea3ad021ad871)
- [fix: localStorage의 userId 숫자로 변환](https://github.com/SomSomParty/SomSomParty_FE/pull/27/commits/9f4ef1a03fc27de49c80f0df82eb2a4281e8a728)
## 💬 리뷰 요구사항
> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요

채팅방 진입(메시지 내역 조회), 채팅 전송 부분 확인 부탁드립니다. 
채팅방 목록 조회, 참여, 나가기까지는 로그인한 유저 정보로 잘 동작합니다. 